### PR TITLE
fix utf16 decode issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ fabric.properties
 *.bak
 
 test/output/*
+
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dart:
 stages:
   - analyze_and_format
   - testing
+  - coverage
   - prepub
   - deploy
 
@@ -19,14 +20,18 @@ jobs:
       name: "Unit tests"
       script: pub run test
     
+    - stage: coverage
+      name: "Test coverage report"
+      script: ./tool/travis/cov.sh
+
     - stage: prepub
       name: "Prepublish checks"
       script: pub publish --dry-run
       
     - stage: deploy
       name: "Deploy on pub.dartlang.org"
-      if: branch = master
-      script: skip
+      #if: branch = master
+      #script: skip
       deploy:
         provider: script
         script: ./tool/travis/pub.sh

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: # [NiKoTron]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: nikotron
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dart Tags
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/10f86d6f399346239482d19a7072becc)](https://app.codacy.com/app/NiKoTron/dart-tags?utm_source=github.com&utm_medium=referral&utm_content=NiKoTron/dart-tags&utm_campaign=Badge_Grade_Dashboard)
+[![Coverage Status](https://coveralls.io/repos/github/NiKoTron/dart-tags/badge.svg?branch=master)](https://coveralls.io/github/NiKoTron/dart-tags?branch=master)
 [![pub package](https://img.shields.io/pub/v/dart_tags.svg)](https://pub.dartlang.org/packages/dart_tags) [![Build Status](https://travis-ci.org/NiKoTron/dart-tags.svg?branch=master)](https://travis-ci.org/NiKoTron/dart-tags)
 [![Awesome Dart](https://img.shields.io/badge/Awesome-Dart-blue.svg?longCache=true)](https://github.com/yissachar/awesome-dart#parsers)
 

--- a/lib/src/convert/utf16.dart
+++ b/lib/src/convert/utf16.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:utf/utf.dart';
+
 class UTF16 extends Encoding {
   @override
   Converter<List<int>, String> get decoder => _UTF16Decoder();
@@ -14,7 +16,7 @@ class UTF16 extends Encoding {
 class _UTF16Decoder extends Converter<List<int>, String> {
   @override
   String convert(List<int> input) {
-    return String.fromCharCodes(input);
+    return decodeUtf16le(input, 0, input.length);
   }
 }
 

--- a/lib/src/frames/frame.dart
+++ b/lib/src/frames/frame.dart
@@ -1,12 +1,12 @@
+import 'dart:convert';
+
 import 'package:dart_tags/src/frames/id3v2/apic_frame.dart';
 import 'package:dart_tags/src/frames/id3v2/comm_frame.dart';
 import 'package:dart_tags/src/frames/id3v2/txxx_frame.dart';
 import 'package:dart_tags/src/frames/id3v2/wxxx_frame.dart';
+import 'package:dart_tags/src/model/consts.dart' as consts;
 
 import 'id3v2/default_frame.dart';
-import 'id3v2/id3v2_frame.dart';
-
-import 'package:dart_tags/src/model/consts.dart' as consts;
 
 abstract class Frame<T> {
   List<int> encode(T value, [String key]);
@@ -57,8 +57,7 @@ class FramesID3V24 {
     assert(data is List<int> || data is String);
 
     if (data is List<int>) {
-      final encoding = ID3V2Frame.getEncoding(data[ID3V2Frame.headerLength]);
-      final tag = encoding.decode(data.sublist(0, 4));
+      final tag = latin1.decode(data.sublist(0, 4));
       return _getFrame(consts.framesV23_V24[tag] ?? tag);
     } else if (data is String) {
       return _getFrame(getTagByPseudonym(data));

--- a/lib/src/frames/id3v2/id3v2_frame.dart
+++ b/lib/src/frames/id3v2/id3v2_frame.dart
@@ -25,8 +25,7 @@ abstract class ID3V2Frame<T> implements Frame<T> {
 
   @override
   MapEntry<String, T> decode(List<int> data) {
-    final encoding = getEncoding(data[headerLength]);
-    final tag = encoding.decode(data.sublist(0, 4));
+    final tag = latin1.decode(data.sublist(0, 4));
     if (!consts.framesHeaders.keys.contains(tag)) {
       print('$tag unknown tag');
       return null;
@@ -37,6 +36,7 @@ abstract class ID3V2Frame<T> implements Frame<T> {
       return null;
     }
 
+    final encoding = getEncoding(data[headerLength]);
     _header = ID3V2FrameHeader(tag, encoding, size);
 
     print('${data.length}, ${headerLength}, ${_header.length}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,3 +10,4 @@ environment:
 dev_dependencies:
   pedantic: ^1.8.0+1
   test: ^1.6.5
+  utf: ^0.9.0+5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,9 @@ author: NiKoTron <nickolay.simonov@gmail.com>
 environment:
   sdk: '>=2.3.0 <3.0.0' 
 
+dependencies:
+  utf: ^0.9.0+5
+
 dev_dependencies:
   pedantic: ^1.8.0+1
   test: ^1.6.5
-  utf: ^0.9.0+5

--- a/tool/travis/cov.sh
+++ b/tool/travis/cov.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+export REPO_TOKEN=RltkmM2Z4YjS0yAjabbeiuWHOy4b6sv32
+
+# Install dart_coveralls; gather and send coverage data.
+if [ "$REPO_TOKEN" ]; then
+  pub global activate dart_coveralls
+  pub global run dart_coveralls report \
+    --token $REPO_TOKEN \
+    --retry 2 \
+    --exclude-test-files \
+    test/dart_tags_test.dart
+fi


### PR DESCRIPTION
Thank for your awesome effort on this library. I'm using it to parse the ID3v2 tags for some international files, and encounter issues when some frame is encoded with utf16. In which case it doesn't work well.

Finally I figured out there where two issues:

1. when trying to get the frame identifier, it has no need to use the evaluated  encoding type, since it always guaranteed to be 4 chars.
2. when decode utf16 code point, what you got as input is not the code point itself. For example, the code point of Chinese character "人" 's codepoint is `\xbaN`, but what you got as input is: `[186, 78]`. So you should not directly use `String.fromCodePoints()`. Instead use the official lib utf. 